### PR TITLE
Fix lint errors in `src/fibRoute.ts`

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,9 @@
 // Endpoint for querying the fibonacci numbers
 
 import fibonacci from "./fib";
+import type {Request, Response} from 'express';
 
-export default (req, res) => {
+export default (req : Request, res : Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
Please review!

Imported `Request` and `Response` types from `express`, and added type annotations to fix linter errors as described [here](https://stackoverflow.com/questions/58567145/types-for-req-and-res-in-express/58567246#58567246).

Fixes #2.